### PR TITLE
IOError -> OSError

### DIFF
--- a/fw/core/code.py
+++ b/fw/core/code.py
@@ -130,7 +130,7 @@ try:
                     error_mode()
                 key_seq = key_seq + key
             priority_words[key_seq] = line       
-except IOError:
+except OSError:
     pass
 
 # Choose mode based on held keys at startup


### PR DESCRIPTION
There is no `IOError` in CircuitPython; I think you mean `OSError`. This came up because a user did not have a `priority_words.txt` file.

(Encountered this while helping a user in the Adafruit discord server.)